### PR TITLE
globi index config and replacing \xa0 characters with whitespaces

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches: [ '*' ]
   schedule:
-    - cron: "* * * * 1"
+    - cron: "0 0 * * 1"
 
 jobs:
   build:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,23 @@
+# This workflow will review a GloBI indexed dataset.
+# For more information see: https://globalbioticinteractions.org
+
+name: GloBI review by Elton
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+  schedule:
+    - cron: "* * * * 1"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: download review script
+        run: curl --silent -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/check-dataset.sh" > check-dataset.sh
+      - name: review dataset
+        run: bash check-dataset.sh "${GITHUB_REPOSITORY}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+datasets/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+install:
+  - curl -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/check-dataset.sh"
+    > check-dataset.sh
+  - chmod +x check-dataset.sh
+script: "./check-dataset.sh ${TRAVIS_REPO_SLUG}"

--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ As with any form of data collection, we are aware there will likely be errors wi
 - Including other species not included in MammalDIET:
     - Dingos (Canis dingo)
     - Feral cats (Felis catus)
+
+# Indexing
+
+ [![GloBI](http://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:globalbioticinteractions/CarniDIET-Database)](http://globalbioticinteractions.org/?accordingTo=globi:globalbioticinteractions/CarniDIET-Database)
+
+CarniDIET is configured to be indexed by Global Biotic Interactions (GloBI, https://globalbioticinteractions.org) index.

--- a/globi.json
+++ b/globi.json
@@ -1,0 +1,238 @@
+{
+  "@context" : [ "http://www.w3.org/ns/csvw", {
+    "@language" : "en"
+  } ],
+  "rdfs:comment" : [ "inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/" ],
+  "tables" : [ {
+    "@context" : [ "http://www.w3.org/ns/csvw", {
+      "@language" : "en"
+    } ],
+    "rdfs:comment" : [ "inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/" ],
+    "url" : "Version%201.0/CarniDIET%201.0.csv",
+    "dcterms:bibliographicCitation" : "Middleton, O.S, Svensson, H, Scharlemann, J.P.W, Faurby, S, Sandom, C.J. CarniDIET 1.0: A database of terrestrial carnivorous mammal diets. Global Ecology and Biogeography. https://doi.org/10.1111/geb.13296.",
+    "doi" : "10.1111/geb.13296",
+    "interactionTypeId" : "http://purl.obolibrary.org/obo/RO_0002470",
+    "interactionTypeName" : "eats",
+    "delimiter" : ",",
+    "headerRowCount" : 1,
+    "null" : [ "NA" ],
+    "tableSchema" : {
+      "columns" : [ {
+        "name" : "recordID",
+        "titles" : "recordID",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonOrder",
+        "titles" : "orderCarni",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonFamily",
+        "titles" : "familyCarni",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonName",
+        "titles" : "scientificNameCarni",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTaxonCommonName",
+        "titles" : "commonNameCarni",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceSexName",
+        "titles" : "sexCarni",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceLifeStageName",
+        "titles" : "lifeStageCarni",
+        "datatype" : "string"
+      }, {
+        "name" : "foodType",
+        "titles" : "foodType",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonOrder",
+        "titles" : "orderPrey",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonFamily",
+        "titles" : "familyPrey",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonGenus",
+        "titles" : "genusPrey",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonSpecificEpithet",
+        "titles" : "speciesPrey",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonName",
+        "titles" : "scientificNamePrey",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonCommonName",
+        "titles" : "commonNamePrey",
+        "datatype" : "string"
+      }, {
+        "name" : "domesticOrAgricultural",
+        "titles" : "domesticOrAgricultural",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonRankName",
+        "titles" : "taxonRankPrey",
+        "datatype" : "string"
+      }, {
+        "name" : "percentage",
+        "titles" : "percentage",
+        "datatype" : "string"
+      }, {
+        "name" : "percentageError",
+        "titles" : "percentageError",
+        "datatype" : "string"
+      }, {
+        "name" : "basisOfRecordName",
+        "titles" : "dataBasisFromSource",
+        "datatype" : "string"
+      }, {
+        "name" : "sampleSizeScatStomachTissue",
+        "titles" : "sampleSizeScatStomachTissue",
+        "datatype" : "string"
+      }, {
+        "name" : "sampleSizeKillsPreyItems",
+        "titles" : "sampleSizeKillsPreyItems",
+        "datatype" : "string"
+      }, {
+        "name" : "http://rs.tdwg.org/dwc/terms/eventDate",
+        "titles" : "startYear",
+        "datatype" : {
+            "basis" : "date",
+            "format" : "YYYY"
+        }
+      }, {
+        "name" : "endYear",
+        "titles" : "endYear",
+        "datatype" : "string"
+      }, {
+        "name" : "startMonth",
+        "titles" : "startMonth",
+        "datatype" : "string"
+      }, {
+        "name" : "endMonth",
+        "titles" : "endMonth",
+        "datatype" : "string"
+      }, {
+        "name" : "fixedBetweenMonths",
+        "titles" : "fixedBetweenMonths",
+        "datatype" : "string"
+      }, {
+        "name" : "startDayOfYear",
+        "titles" : "startDayOfYear",
+        "datatype" : "string"
+      }, {
+        "name" : "endDayOfYear",
+        "titles" : "endDayOfYear",
+        "datatype" : "string"
+      }, {
+        "name" : "season",
+        "titles" : "season",
+        "datatype" : "string"
+      }, {
+        "name" : "altitude",
+        "titles" : "minimumElevationInMeters",
+        "datatype" : "string"
+      }, {
+        "name" : "maximumElevationInMeters",
+        "titles" : "maximumElevationInMeters",
+        "datatype" : "string"
+      }, {
+        "name" : "geographicRegion",
+        "titles" : "geographicRegion",
+        "datatype" : "string"
+      }, {
+        "name" : "country",
+        "titles" : "country",
+        "datatype" : "string"
+      }, {
+        "name" : "stateProvince",
+        "titles" : "stateProvince",
+        "datatype" : "string"
+      }, {
+        "name" : "county",
+        "titles" : "county",
+        "datatype" : "string"
+      }, {
+        "name" : "municipality",
+        "titles" : "municipality",
+        "datatype" : "string"
+      }, {
+        "name" : "localityName",
+        "titles" : "verbatimLocality",
+        "datatype" : "string"
+      }, {
+        "name" : "protectedAreaHigher",
+        "titles" : "protectedAreaHigher",
+        "datatype" : "string"
+      }, {
+        "name" : "protectedAreaLower",
+        "titles" : "protectedAreaLower",
+        "datatype" : "string"
+      }, {
+        "name" : "islandGroup",
+        "titles" : "islandGroup",
+        "datatype" : "string"
+      }, {
+        "name" : "island",
+        "titles" : "island",
+        "datatype" : "string"
+      }, {
+        "name" : "studyAreaSize",
+        "titles" : "studyAreaSize",
+        "datatype" : "string"
+      }, {
+        "name" : "decimalLatitude",
+        "titles" : "decimalLatitude",
+        "datatype" : "string"
+      }, {
+        "name" : "decimalLongitude",
+        "titles" : "decimalLongitude",
+        "datatype" : "string"
+      }, {
+        "name" : "georeferenceSources",
+        "titles" : "georeferenceSources",
+        "datatype" : "string"
+      }, {
+        "name" : "samplingProtocol",
+        "titles" : "samplingProtocol",
+        "datatype" : "string"
+      }, {
+        "name" : "methodQuantification",
+        "titles" : "methodQuantification",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceAuthor",
+        "titles" : "sourceAuthor",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceYear",
+        "titles" : "sourceYear",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceTitle",
+        "titles" : "sourceTitle",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceJournal",
+        "titles" : "sourceJournal",
+        "datatype" : "string"
+      }, {
+        "name" : "referenceCitation",
+        "titles" : "sourcePrimaryReference",
+        "datatype" : "string"
+      }, {
+        "name" : "sourceCollectionReference",
+        "titles" : "sourceCollectionReference",
+        "datatype" : "string"
+      } ]
+    }
+  } ]
+}


### PR DESCRIPTION
Hi @osmiddleton -

As discussed in https://github.com/globalbioticinteractions/globalbioticinteractions/issues/642 , I've prepared a configuration to let CarniDIET be indexed by GloBI. 

Also, this pull requests includes a modification that replaced funky ```\xa0``` character with normal white spaces to avoid character encoding issues as seen in citation strings like ```Zamani, Navid, et al. "Predation of montane deserts ungulates by Asiatic cheetah Acinonyx jubatus venaticus in Central Iran."�Folia Zoologica�66.1 (2017): 50-57. .```

Thanks again for putting together such a rich dataset and I hope my contributions help to more easily find and use your database.

-jorrit